### PR TITLE
Fix to make it work with Xcode 6.1 beta

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2387,7 +2387,7 @@ function m_handler()
                     M_XCODE51_VERSION=$m_xcode_version
                 fi
                 ;;
-            6.0*)
+            6.0*|6.1*)
                 m_version_compare $M_XCODE60_VERSION $m_xcode_version
                 if [[ $? != 2 ]]
                 then


### PR DESCRIPTION
This horrid workaround makes osxfuse work with Xcode 6.1 beta on Yosemite.
