### PR TITLE
Adds (partial) support for Xcode 3.1.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -594,7 +594,7 @@ function m_handler_reload()
     fi
 
     local kextload_dev="kextutil"
-    if [ ! -x $kextload_dev ]
+    if [ ! -x $(which $kextload_dev) ]
     then
         kextload_dev="kextload"
     fi


### PR DESCRIPTION
Since Xcode 3.1.4 is the last version which runs under 10.5, native
builds aren't possible on 10.5 without Xcode 3.1 support.  There are
at least three changes needed to fully support Xcode 3.1, only two
of which are included here:

1) Adding 3.1 entries to the Xcode-version-specific areas.

2) Falling back to kextload when kextutil is not present.  In
10.5/3.1, the developer-only kextload options had not yet been
split off into kextutil, making kextload a drop-in replacement.

3) Providing a substitute for pkgbuild, which is missing in the
10.5/3.1 environment.  There does not appear to be a trivial
solution to this one.

Without a fix for item 3, the "dist" and "smalldist" targets still
don't work in 10.5/3.1, but the other targets do, including the
"homebrew" target used by MacPorts.
