### PR TITLE
Manually merged master-branch version of #190

### DIFF
--- a/build.d/targets/release.sh
+++ b/build.d/targets/release.sh
@@ -172,33 +172,44 @@ EOF
 
     # Adjust view options of disk image
 
-osascript 1>&3 2>&4 <<EOF
-tell application "Finder"
-    tell disk "FUSE for OS X"
-        open
-        delay 1
-        set current view of container window to icon view
-        set toolbar visible of container window to false
-        set the bounds of container window to {0, 0, 550, 325}
-        set theViewOptions to the icon view options of container window
-        set arrangement of theViewOptions to not arranged
-        set icon size of theViewOptions to 96
-        set text size of theViewOptions to 12
-        set background picture of theViewOptions to file ".background:background.tiff"
-        set position of item "License" of container window to {125, 165}
-        set position of item "FUSE for OS X" of container window to {275, 165}
-        set position of item "Extras" of container window to {425, 165}
-        delay 1
-        update without registering applications
-        delay 1
-        close
-    end tell
-end tell
+    if [ -f "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/xDS_Store" ]
+    then
+        # Use saved window settings if available.
+        /bin/cp "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/xDS_Store" "${disk_image_mount_point}/.DS_Store"
+    else
+        # NOTE: If any of the window parameters below have changed, remove the
+        # xDS_Store file so that the .DS_Store file (and it) will be recomputed.
+        osascript 1>&3 2>&4 <<EOF
+        tell application "Finder"
+            tell disk "FUSE for OS X"
+                open
+                delay 1
+                set current view of container window to icon view
+                set toolbar visible of container window to false
+                set the bounds of container window to {0, 0, 550, 325}
+                set theViewOptions to the icon view options of container window
+                set arrangement of theViewOptions to not arranged
+                set icon size of theViewOptions to 96
+                set text size of theViewOptions to 12
+                set background picture of theViewOptions to file ".background:background.tiff"
+                set position of item "License" of container window to {125, 165}
+                set position of item "FUSE for OS X" of container window to {275, 165}
+                set position of item "Extras" of container window to {425, 165}
+                delay 1
+                update without registering applications
+                delay 1
+                close
+                delay 5
+            end tell
+        end tell
 EOF
+    fi
     detach_die_on_error "Failed to adjust disk image view options"
 
     sync
     sleep 1
+    # Capture the .DS_Store file for future builds.
+    /bin/cp -pX "${disk_image_mount_point}/.DS_Store" "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/xDS_Store"
 
     # Detach disk image
 

--- a/build.d/targets/release.sh
+++ b/build.d/targets/release.sh
@@ -115,7 +115,7 @@ function release_build
 
     # Copy license to disk image
 
-    /bin/cp -a "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/License.rtf" "${disk_image_mount_point}/License.rtf" 1>&3 2>&4
+    /bin/cp -pPR "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/License.rtf" "${disk_image_mount_point}/License.rtf" 1>&3 2>&4
     detach_die_on_error "Failed to copy license to disk image"
 
     /usr/bin/xcrun SetFile -a E "${disk_image_mount_point}/License.rtf" 1>&3 2>&4
@@ -123,7 +123,7 @@ function release_build
 
     # Copy extras to disk image
 
-    /bin/cp -a "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/Extras" "${disk_image_mount_point}/Extras" 1>&3 2>&4
+    /bin/cp -pPR "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/Extras" "${disk_image_mount_point}/Extras" 1>&3 2>&4
     detach_die_on_error "Failed to copy extras to disk image"
 
     /usr/bin/xcrun SetFile -a E "${disk_image_mount_point}/Extras"/* 1>&3 2>&4
@@ -143,7 +143,7 @@ function release_build
     local disk_image_distribution_package_relative_path="Extras/FUSE for OS X ${osxfuse_version}.pkg"
     local disk_image_distribution_package_path="${disk_image_mount_point}/${disk_image_distribution_package_relative_path}"
 
-    /bin/cp -a "${distribution_package_path}" "${disk_image_distribution_package_path}" 1>&3 2>&4
+    /bin/cp -pPR "${distribution_package_path}" "${disk_image_distribution_package_path}" 1>&3 2>&4
     detach_die_on_error "Failed to copy distribution package to disk image"
 
     /usr/bin/xcrun SetFile -a E "${disk_image_distribution_package_path}" 1>&3 2>&4
@@ -167,7 +167,7 @@ EOF
     # Copy custom background to disk image
 
     /bin/mkdir -p "${disk_image_mount_point}/.background" 1>&3 2>&4 && \
-    /bin/cp -a "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/background.tiff" "${disk_image_mount_point}/.background/background.tiff" 1>&3 2>&4
+    /bin/cp -pPR "${BUILD_SOURCE_DIRECTORY}/support/DiskImage/background.tiff" "${disk_image_mount_point}/.background/background.tiff" 1>&3 2>&4
     detach_die_on_error "Failed to copy background image to disk image"
 
     # Adjust view options of disk image

--- a/build.d/targets/release.sh
+++ b/build.d/targets/release.sh
@@ -206,6 +206,7 @@ EOF
     fi
     detach_die_on_error "Failed to adjust disk image view options"
 
+    common_sudo "Enter password to remove the .Trashes directory from the disk image" rm -rf "${disk_image_mount_point}/.Trashes"
     sync
     sleep 1
     # Capture the .DS_Store file for future builds.

--- a/build.sh
+++ b/build.sh
@@ -554,7 +554,7 @@ function build_target_install
         common_assert "[[ ! -e `string_escape "${target}"` ]]" "Target is already installed"
     fi
 
-    local -a command=(/bin/cp -a "${source}" "${target}")
+    local -a command=(/bin/cp -pPR "${source}" "${target}")
     if (( root == 0 ))
     then
         "${command[@]}" 1>&3 2>&4


### PR DESCRIPTION
This manually merges the first two commits from #190, adjusting for the file reorganization.  See the comments there for details.

I have *not* tested this version of those commits, due to multiple issues preventing my building the release target on my system (having nothing to do with these changes).

For this reason (and the fact that the changed window parameters prevent merely copying the file from the osxfuse-2 branch), there's no commit with an initial xDS_Store file included.
